### PR TITLE
OpenBSD 6.9 fix route inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+**.o
+**.core
+44ripd
+amprroute
+testbitvec
+testipmapfind
+testipmapinsert
+testipmapnearest
+testisvalidnetmask
+testnetmask2cidr
+testrevbits
+uptunnel
+

--- a/main.c
+++ b/main.c
@@ -73,8 +73,8 @@ enum {
 	TIMEOUT = 15*60,	// 15 minutes.
 };
 
-const char *DEFAULT_LOCAL_ADDRESS = "23.30.150.141";
-const char *DEFAULT_LOCAL_44ADDRESS = "44.44.107.1";
+const char *DEFAULT_LOCAL_ADDRESS = "10.5.0.28";
+const char *DEFAULT_LOCAL_44ADDRESS = "44.94.84.0";
 const char *DEFAULT_GATEWAY_ADDRESS = "169.228.34.84";
 const char *RIPV2_GROUP = "224.0.0.9";
 const char *PASSWORD = "pLaInTeXtpAsSwD";
@@ -300,9 +300,9 @@ mkroute(uint32_t ipnet, uint32_t subnetmask, uint32_t gateway)
 	route = calloc(1, sizeof(*route));
 	if (route == NULL)
 		fatal("malloc");
-	route->ipnet = htonl(ipnet);
-	route->subnetmask = htonl(subnetmask);
-	route->gateway = htonl(gateway);
+	route->ipnet = ipnet;
+	route->subnetmask = subnetmask;
+	route->gateway = gateway;
 
 	return route;
 }

--- a/main.c
+++ b/main.c
@@ -73,8 +73,8 @@ enum {
 	TIMEOUT = 15*60,	// 15 minutes.
 };
 
-const char *DEFAULT_LOCAL_ADDRESS = "10.5.0.28";
-const char *DEFAULT_LOCAL_44ADDRESS = "44.94.84.0";
+const char *DEFAULT_LOCAL_ADDRESS = "23.30.150.141";
+const char *DEFAULT_LOCAL_44ADDRESS = "44.44.107.1";
 const char *DEFAULT_GATEWAY_ADDRESS = "169.228.34.84";
 const char *RIPV2_GROUP = "224.0.0.9";
 const char *PASSWORD = "pLaInTeXtpAsSwD";

--- a/openbsd/sys.c
+++ b/openbsd/sys.c
@@ -330,7 +330,8 @@ rmroute(Route *route, int rtable)
 void
 ipaddrstr(uint32_t addr, char buf[static INET_ADDRSTRLEN])
 {
-	inet_ntop(AF_INET, &addr, buf, INET_ADDRSTRLEN);
+	uint32_t l_addr = htonl(addr);
+	inet_ntop(AF_INET, &l_addr, buf, INET_ADDRSTRLEN);
 }
 
 void
@@ -340,9 +341,9 @@ routestr(Route *route, Tunnel *tunnel, char *buf, size_t size)
 	size_t cidr;
 
 	assert(route != NULL);
-	cidr = netmask2cidr(route->subnetmask);
-	ipaddrstr(route->ipnet, proute);
-	ipaddrstr(route->gateway, gw);
+	cidr = netmask2cidr(ntohl(route->subnetmask));
+	ipaddrstr(ntohl(route->ipnet), proute);
+	ipaddrstr(ntohl(route->gateway), gw);
 
 	assert(buf != NULL);
 	snprintf(buf, size, "%s/%zu -> %s", proute, cidr, gw);


### PR DESCRIPTION
I'm pretty sure this isn't the most elegant fix, but 44ripd did not work on my OpenBSD 6.9 install before making these changes.

44.0.0.1 was 1.0.0.44, and a CIDR mask of /24 for example, would be set as /4294967295 instead of what they should have been.